### PR TITLE
Adds oauth2client module to READMEs

### DIFF
--- a/admin_sdk/directory/README.md
+++ b/admin_sdk/directory/README.md
@@ -9,7 +9,7 @@ Directory API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/admin_sdk/reports/README.md
+++ b/admin_sdk/reports/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reports API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/admin_sdk/reseller/README.md
+++ b/admin_sdk/reseller/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reseller API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/apps_script/quickstart/README.md
+++ b/apps_script/quickstart/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Apps Script API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/calendar/quickstart/README.md
+++ b/calendar/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Calendar API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/classroom/quickstart/README.md
+++ b/classroom/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Classroom API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/drive/driveapp/README.md
+++ b/drive/driveapp/README.md
@@ -21,12 +21,12 @@ Step 2: Install the Google Client Library
 
 To install the Google API Python Client on a system, you should use the `pip` command.
 
-    pip install --upgrade google-api-python-client
+    pip install --upgrade google-api-python-client oauth2client
 
 Alternatively, if you are using `virtualenv`, create the environment and install the client library.
 
     virtualenv ve
-    ./ve/bin/pip install --upgrade google-api-python-client
+    ./ve/bin/pip install --upgrade google-api-python-client oauth2client
 
 If you need to access the Google API Python Client from a Google App Engine
 project, you can follow the instructions

--- a/drive/quickstart/README.md
+++ b/drive/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Drive V3 API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/gmail/quickstart/README.md
+++ b/gmail/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Gmail API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/people/quickstart/README.md
+++ b/people/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google People API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/sheets/quickstart/README.md
+++ b/sheets/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Sheets API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 

--- a/sheets/snippets/install.sh
+++ b/sheets/snippets/install.sh
@@ -2,5 +2,5 @@
 command -v virtualenv >/dev/null 2>&1 || { echo >&2 "virtualenv required, aborting."; exit 1; }
 virtualenv "env" &&
 source "env/bin/activate" &&
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 deactivate

--- a/slides/quickstart/README.md
+++ b/slides/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Slides API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/slides/snippets/install.sh
+++ b/slides/snippets/install.sh
@@ -2,5 +2,5 @@
 command -v virtualenv >/dev/null 2>&1 || { echo >&2 "virtualenv required, aborting."; exit 1; }
 virtualenv "env" &&
 source "env/bin/activate" &&
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 deactivate

--- a/tasks/quickstart/README.md
+++ b/tasks/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Tasks API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run

--- a/vault/quickstart/README.md
+++ b/vault/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Vault API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client
+pip install --upgrade google-api-python-client oauth2client
 ```
 
 ## Run


### PR DESCRIPTION
Update the quickstart READMEs to include the installation of the oauth2client module, since it is no longer a dependency of the client library.