### PR TITLE
Fix Drive Quickstart error on File names with unicode chars

### DIFF
--- a/drive/quickstart/quickstart.py
+++ b/drive/quickstart/quickstart.py
@@ -42,7 +42,7 @@ def main():
     else:
         print('Files:')
         for item in items:
-            print('{0} ({1})'.format(item['name'], item['id']))
+            print(u'{0} ({1})'.format(item['name'], item['id']))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If a file name has a unicode character such as "Édouard". The current print line will throw an error:
Traceback (most recent call last):
  File "quickstart.py", line 50, in <module>
    main()
  File "quickstart.py", line 47, in main
    print('{0} ({1})'.format(item['name'], item['id']))

We simply need to change it to: print(u'{0} ({1})'.format(item['name'], item['id']))