### PR TITLE
Fix print formatting on strings that might contain unicode chars

### DIFF
--- a/admin_sdk/directory/quickstart.py
+++ b/admin_sdk/directory/quickstart.py
@@ -43,7 +43,7 @@ def main():
     else:
         print('Users:')
         for user in users:
-            print('{0} ({1})'.format(user['primaryEmail'],
+            print(u'{0} ({1})'.format(user['primaryEmail'],
                 user['name']['fullName']))
 
 

--- a/admin_sdk/reports/quickstart.py
+++ b/admin_sdk/reports/quickstart.py
@@ -43,7 +43,7 @@ def main():
     else:
         print('Logins:')
         for activity in activities:
-            print('{0}: {1} ({2})'.format(activity['id']['time'],
+            print(u'{0}: {1} ({2})'.format(activity['id']['time'],
                 activity['actor']['email'], activity['events'][0]['name']))
 
 if __name__ == '__main__':

--- a/admin_sdk/reseller/quickstart.py
+++ b/admin_sdk/reseller/quickstart.py
@@ -43,7 +43,7 @@ def main():
     else:
         print('Logins:')
         for activity in activities:
-            print('{0}: {1} ({2})'.format(activity['id']['time'],
+            print(u'{0}: {1} ({2})'.format(activity['id']['time'],
                 activity['actor']['email'], activity['events'][0]['name']))
 
 if __name__ == '__main__':

--- a/drive/activity/quickstart.py
+++ b/drive/activity/quickstart.py
@@ -50,7 +50,7 @@ def main():
                 continue
             time = datetime.datetime.fromtimestamp(
                 int(event['eventTimeMillis'])/1000)
-            print('{0}: {1}, {2}, {3} ({4})'.format(time, user['name'],
+            print(u'{0}: {1}, {2}, {3} ({4})'.format(time, user['name'],
                 event['primaryEventType'], target['name'], target['mimeType']))
 
 if __name__ == '__main__':

--- a/tasks/quickstart/quickstart.py
+++ b/tasks/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
     else:
         print('Task lists:')
         for item in items:
-            print('{0} ({1})'.format(item['title'], item['id']))
+            print(u'{0} ({1})'.format(item['title'], item['id']))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
If a string has a unicode character such as "Édouard".  Print line will throw an error:
Traceback (most recent call last):
File "quickstart.py", line 50, in 
main()
File "quickstart.py", line 47, in main
print('{0} ({1})'.format(item['name'], item['id']))

We simply need to change it to: print(u'{0} ({1})'.format(item['name'], item['id']))

*Note, not all .format's in this repo need this change, just ones primarily dealing with user created strings.