### PR TITLE
Adding python quickstart for Drive Activity API v2.

### DIFF
--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -1,0 +1,91 @@
+from __future__ import print_function
+import datetime
+from googleapiclient.discovery import build
+from httplib2 import Http
+from oauth2client import file, client, tools
+
+# If modifying these scopes, delete the file token.json.
+SCOPES = 'https://www.googleapis.com/auth/drive.activity.readonly'
+
+
+def main():
+  """Shows basic usage of the Drive Activity API.
+    Prints information about the last 10 events that occured the user's Drive.
+    """
+  # The file token.json stores the user's access and refresh tokens, and is
+  # created automatically when the authorization flow completes for the first
+  # time.
+  store = file.Storage('token.json')
+  creds = store.get()
+  if not creds or creds.invalid:
+    flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
+    creds = tools.run_flow(flow, store)
+  service = build('driveactivity', 'v2', http=creds.authorize(Http()))
+
+  # Call the Drive Activity API
+  results = service.activity().query(body={
+      'pageSize': 10,
+      'consolidationStrategy': {
+          'legacy': {}
+      }
+  }).execute()
+  activities = results.get('activities', [])
+
+  if not activities:
+    print('No activity.')
+  else:
+    print('Recent activity:')
+    for activity in activities:
+      time = getTimeInfo(activity)
+      action = getActionInfo(activity['primaryActionDetail'])
+      actors = map(getActorInfo, activity['actors'])
+      targets = map(getTargetInfo, activity['targets'])
+      print(u'{0}: {1}, {2}, {3}'.format(time, truncated(actors), action,
+                                         truncated(targets)))
+
+
+def truncated(array, limit=2):
+  contents = ', '.join(array[:limit])
+  more = '' if len(array) <= limit else ', ...'
+  return '[' + contents + more + ']'
+
+
+def getTimeInfo(activity):
+  if 'timestamp' in activity:
+    return activity['timestamp']
+  if 'timeRange' in activity:
+    return activity['timeRange']['endTime']
+  return 'unknown'
+
+
+def getActionInfo(actionDetail):
+  return next(iter(actionDetail))
+
+
+def getUserInfo(user):
+  if 'knownUser' in user:
+    knownUser = user['knownUser']
+    isMe = knownUser.get('isCurrentUser', False)
+    return u'people/me' if isMe else knownUser['personName']
+  return next(iter(user))
+
+
+def getActorInfo(actor):
+  if 'user' in actor:
+    return getUserInfo(actor['user'])
+  return next(iter(actor))
+
+
+def getTargetInfo(target):
+  if 'driveItem' in target:
+    return 'driveItem:"' + target['driveItem'].get('title', 'unknown') + '"'
+  if 'teamDrive' in target:
+    return 'teamDrive:"' + target['teamDrive'].get('title', 'unknown') + '"'
+  if 'fileComment' in target:
+    parent = target['fileComment'].get('parent', {})
+    return 'fileComment:"' + parent.get('title', 'unknown') + '"'
+  return next(iter(target))
+
+
+if __name__ == '__main__':
+  main()

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -47,8 +47,8 @@ def truncated(array, limit=2):
     return u'[{0}{1}]'.format(contents, more)
 
 
-def getOneOf(object):
-    for key in object:
+def getOneOf(obj):
+    for key in obj:
         return key
     return 'unknown'
 

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # [START drive_activity_v2_quickstart]
 from __future__ import print_function
 from googleapiclient.discovery import build

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import datetime
 from googleapiclient.discovery import build
 from httplib2 import Http
 from oauth2client import file, client, tools
@@ -9,83 +8,84 @@ SCOPES = 'https://www.googleapis.com/auth/drive.activity.readonly'
 
 
 def main():
-  """Shows basic usage of the Drive Activity API.
+    """Shows basic usage of the Drive Activity API.
+
     Prints information about the last 10 events that occured the user's Drive.
     """
-  # The file token.json stores the user's access and refresh tokens, and is
-  # created automatically when the authorization flow completes for the first
-  # time.
-  store = file.Storage('token.json')
-  creds = store.get()
-  if not creds or creds.invalid:
-    flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-    creds = tools.run_flow(flow, store)
-  service = build('driveactivity', 'v2', http=creds.authorize(Http()))
+    # The file token.json stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    store = file.Storage('token.json')
+    creds = store.get()
+    if not creds or creds.invalid:
+        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
+        creds = tools.run_flow(flow, store)
+    service = build('driveactivity', 'v2', http=creds.authorize(Http()))
 
-  # Call the Drive Activity API
-  results = service.activity().query(body={
-      'pageSize': 10,
-      'consolidationStrategy': {
-          'legacy': {}
-      }
-  }).execute()
-  activities = results.get('activities', [])
+    # Call the Drive Activity API
+    results = service.activity().query(body={
+        'pageSize': 10,
+        'consolidationStrategy': {
+            'legacy': {}
+        }
+    }).execute()
+    activities = results.get('activities', [])
 
-  if not activities:
-    print('No activity.')
-  else:
-    print('Recent activity:')
-    for activity in activities:
-      time = getTimeInfo(activity)
-      action = getActionInfo(activity['primaryActionDetail'])
-      actors = map(getActorInfo, activity['actors'])
-      targets = map(getTargetInfo, activity['targets'])
-      print(u'{0}: {1}, {2}, {3}'.format(time, truncated(actors), action,
-                                         truncated(targets)))
+    if not activities:
+        print('No activity.')
+    else:
+        print('Recent activity:')
+        for activity in activities:
+            time = getTimeInfo(activity)
+            action = getActionInfo(activity['primaryActionDetail'])
+            actors = map(getActorInfo, activity['actors'])
+            targets = map(getTargetInfo, activity['targets'])
+            print(u'{0}: {1}, {2}, {3}'.format(time, truncated(actors), action,
+                                               truncated(targets)))
 
 
 def truncated(array, limit=2):
-  contents = ', '.join(array[:limit])
-  more = '' if len(array) <= limit else ', ...'
-  return '[' + contents + more + ']'
+    contents = ', '.join(array[:limit])
+    more = '' if len(array) <= limit else ', ...'
+    return '[' + contents + more + ']'
 
 
 def getTimeInfo(activity):
-  if 'timestamp' in activity:
-    return activity['timestamp']
-  if 'timeRange' in activity:
-    return activity['timeRange']['endTime']
-  return 'unknown'
+    if 'timestamp' in activity:
+        return activity['timestamp']
+    if 'timeRange' in activity:
+        return activity['timeRange']['endTime']
+    return 'unknown'
 
 
 def getActionInfo(actionDetail):
-  return next(iter(actionDetail))
+    return next(iter(actionDetail))
 
 
 def getUserInfo(user):
-  if 'knownUser' in user:
-    knownUser = user['knownUser']
-    isMe = knownUser.get('isCurrentUser', False)
-    return u'people/me' if isMe else knownUser['personName']
-  return next(iter(user))
+    if 'knownUser' in user:
+        knownUser = user['knownUser']
+        isMe = knownUser.get('isCurrentUser', False)
+        return u'people/me' if isMe else knownUser['personName']
+    return next(iter(user))
 
 
 def getActorInfo(actor):
-  if 'user' in actor:
-    return getUserInfo(actor['user'])
-  return next(iter(actor))
+    if 'user' in actor:
+        return getUserInfo(actor['user'])
+    return next(iter(actor))
 
 
 def getTargetInfo(target):
-  if 'driveItem' in target:
-    return 'driveItem:"' + target['driveItem'].get('title', 'unknown') + '"'
-  if 'teamDrive' in target:
-    return 'teamDrive:"' + target['teamDrive'].get('title', 'unknown') + '"'
-  if 'fileComment' in target:
-    parent = target['fileComment'].get('parent', {})
-    return 'fileComment:"' + parent.get('title', 'unknown') + '"'
-  return next(iter(target))
+    if 'driveItem' in target:
+        return 'driveItem:"' + target['driveItem'].get('title', 'unknown') + '"'
+    if 'teamDrive' in target:
+        return 'teamDrive:"' + target['teamDrive'].get('title', 'unknown') + '"'
+    if 'fileComment' in target:
+        parent = target['fileComment'].get('parent', {})
+        return 'fileComment:"' + parent.get('title', 'unknown') + '"'
+    return next(iter(target))
 
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -24,10 +24,7 @@ def main():
 
     # Call the Drive Activity API
     results = service.activity().query(body={
-        'pageSize': 10,
-        'consolidationStrategy': {
-            'legacy': {}
-        }
+        'pageSize': 10
     }).execute()
     activities = results.get('activities', [])
 
@@ -47,7 +44,13 @@ def main():
 def truncated(array, limit=2):
     contents = ', '.join(array[:limit])
     more = '' if len(array) <= limit else ', ...'
-    return '[' + contents + more + ']'
+    return u'[{0}{1}]'.format(contents, more)
+
+
+def getOneOf(object):
+    for key in object:
+        return key
+    return 'unknown'
 
 
 def getTimeInfo(activity):
@@ -59,7 +62,7 @@ def getTimeInfo(activity):
 
 
 def getActionInfo(actionDetail):
-    return next(iter(actionDetail))
+    return getOneOf(actionDetail)
 
 
 def getUserInfo(user):
@@ -67,24 +70,27 @@ def getUserInfo(user):
         knownUser = user['knownUser']
         isMe = knownUser.get('isCurrentUser', False)
         return u'people/me' if isMe else knownUser['personName']
-    return next(iter(user))
+    return getOneOf(user)
 
 
 def getActorInfo(actor):
     if 'user' in actor:
         return getUserInfo(actor['user'])
-    return next(iter(actor))
+    return getOneOf(actor)
 
 
 def getTargetInfo(target):
     if 'driveItem' in target:
-        return 'driveItem:"' + target['driveItem'].get('title', 'unknown') + '"'
+        title = target['driveItem'].get('title', 'unknown')
+        return 'driveItem:"{0}"'.format(title)
     if 'teamDrive' in target:
-        return 'teamDrive:"' + target['teamDrive'].get('title', 'unknown') + '"'
+        title = target['teamDrive'].get('title', 'unknown')
+        return 'teamDrive:"{0}"'.format(title)
     if 'fileComment' in target:
         parent = target['fileComment'].get('parent', {})
-        return 'fileComment:"' + parent.get('title', 'unknown') + '"'
-    return next(iter(target))
+        title = parent.get('title', 'unknown')
+        return 'fileComment:"{0}"'.format(title)
+    return '{0}:unknown'.format(getOneOf(target))
 
 
 if __name__ == '__main__':

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -1,3 +1,4 @@
+# [START drive_activity_v2_quickstart]
 from __future__ import print_function
 from googleapiclient.discovery import build
 from httplib2 import Http
@@ -95,3 +96,4 @@ def getTargetInfo(target):
 
 if __name__ == '__main__':
     main()
+# [END drive_activity_v2_quickstart]


### PR DESCRIPTION
Started from the v1 quickstart, updated scopes, service names, etc. Since the v2 API is richer, this versoin has some functions to extract human-friendly information from the main object types (actor, action, target). This was intentionally designed to be similar to the other quickstarts (e.g. java, browser-js) in its strategy for interpreting the main object types.