### PR TITLE
[WIP] Switch sheets/quickstart to from oauth2client to google-auth

### DIFF
--- a/admin_sdk/directory/README.md
+++ b/admin_sdk/directory/README.md
@@ -8,7 +8,7 @@ Directory API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/admin_sdk/directory/quickstart.py
+++ b/admin_sdk/directory/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START admin_sdk_directory_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/admin.directory.user'
 
 def main():
     """Shows basic usage of the Admin SDK Directory API.
     Prints the emails and names of the first 10 users in the domain.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('admin', 'directory_v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('admin', 'directory_v1', credentials=creds)
 
     # Call the Admin SDK Directory API
     print('Getting the first 10 users in the domain')

--- a/admin_sdk/reports/README.md
+++ b/admin_sdk/reports/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reports API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/admin_sdk/reports/quickstart.py
+++ b/admin_sdk/reports/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START admin_sdk_reports_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/admin.reports.audit.readonly'
 
 def main():
     """Shows basic usage of the Admin SDK Reports API.
     Prints the time, email, and name of the last 10 login events in the domain.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('admin', 'reports_v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('admin', 'reports_v1', credentials=creds)
 
     # Call the Admin SDK Reports API
     print('Getting the last 10 login events')

--- a/admin_sdk/reseller/README.md
+++ b/admin_sdk/reseller/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reseller API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/admin_sdk/reseller/quickstart.py
+++ b/admin_sdk/reseller/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START admin_sdk_reseller_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/apps.order'
 
 def main():
     """Calls the Admin SDK Reseller API. Prints the customer ID, SKU ID,
     and plan name of the first 10 subscriptions managed by the domain.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('reseller', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('reseller', 'v1', credentials=creds)
 
     # Call the Admin SDK Reseller API
     print('Getting the first 10 subscriptions')

--- a/apps_script/quickstart/README.md
+++ b/apps_script/quickstart/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Apps Script API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/apps_script/quickstart/quickstart.py
+++ b/apps_script/quickstart/quickstart.py
@@ -19,12 +19,14 @@ Call the Apps Script API to create a new script project, upload a file to the
 project, and log the script's URL to the user.
 """
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient import errors
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/script.projects'
 
 SAMPLE_CODE = '''
@@ -43,15 +45,26 @@ SAMPLE_MANIFEST = '''
 def main():
     """Calls the Apps Script API.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('script', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('script', 'v1', credentials=creds)
 
     # Call the Apps Script API
     try:

--- a/calendar/quickstart/README.md
+++ b/calendar/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Calendar API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/calendar/quickstart/quickstart.py
+++ b/calendar/quickstart/quickstart.py
@@ -15,26 +15,39 @@
 # [START calendar_quickstart]
 from __future__ import print_function
 import datetime
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/calendar.readonly'
 
 def main():
     """Shows basic usage of the Google Calendar API.
     Prints the start and name of the next 10 events on the user's calendar.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('calendar', 'v3', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('calendar', 'v3', credentials=creds)
 
     # Call the Calendar API
     now = datetime.datetime.utcnow().isoformat() + 'Z' # 'Z' indicates UTC time

--- a/classroom/quickstart/README.md
+++ b/classroom/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Classroom API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/classroom/quickstart/quickstart.py
+++ b/classroom/quickstart/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START classroom_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/classroom.courses.readonly'
 
 def main():
     """Shows basic usage of the Classroom API.
     Prints the names of the first 10 courses the user has access to.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('classroom', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('classroom', 'v1', credentials=creds)
 
     # Call the Classroom API
     results = service.courses().list(pageSize=10).execute()

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -14,11 +14,13 @@
 
 # [START drive_activity_v2_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/drive.activity.readonly'
 
 
@@ -27,15 +29,26 @@ def main():
 
     Prints information about the last 10 events that occured the user's Drive.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('driveactivity', 'v2', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('driveactivity', 'v2', credentials=creds)
 
     # Call the Drive Activity API
     results = service.activity().query(body={

--- a/drive/activity/quickstart.py
+++ b/drive/activity/quickstart.py
@@ -15,26 +15,39 @@
 # [START drive_activity_quickstart]
 from __future__ import print_function
 import datetime
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/activity'
 
 def main():
     """Shows basic usage of the Drive Activity API.
     Prints information about the last 10 events that occured the user's Drive.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('appsactivity', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('appsactivity', 'v1', credentials=creds)
 
     # Call the Drive Activity API
     results = service.activities().list(source='drive.google.com',

--- a/drive/quickstart/README.md
+++ b/drive/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Drive V3 API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/drive/quickstart/quickstart.py
+++ b/drive/quickstart/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START drive_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/drive.metadata.readonly'
 
 def main():
     """Shows basic usage of the Drive v3 API.
     Prints the names and ids of the first 10 files the user has access to.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('drive', 'v3', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('drive', 'v3', credentials=creds)
 
     # Call the Drive v3 API
     results = service.files().list(

--- a/gmail/quickstart/README.md
+++ b/gmail/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Gmail API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/gmail/quickstart/quickstart.py
+++ b/gmail/quickstart/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START gmail_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/gmail.readonly'
 
 def main():
     """Shows basic usage of the Gmail API.
     Lists the user's Gmail labels.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('gmail', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('gmail', 'v1', credentials=creds)
 
     # Call the Gmail API
     results = service.users().labels().list(userId='me').execute()

--- a/people/quickstart/README.md
+++ b/people/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google People API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/people/quickstart/quickstart.py
+++ b/people/quickstart/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START people_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/contacts.readonly'
 
 def main():
     """Shows basic usage of the People API.
     Prints the name of the first 10 connections.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('people', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('people', 'v1', credentials=creds)
 
     # Call the People API
     print('List 10 connection names')

--- a/sheets/quickstart/README.md
+++ b/sheets/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Sheets API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 

--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -14,11 +14,13 @@
 
 # [START sheets_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/spreadsheets.readonly'
 
 # The ID and range of a sample spreadsheet.
@@ -29,15 +31,26 @@ def main():
     """Shows basic usage of the Sheets API.
     Prints values from a sample spreadsheet.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('sheets', 'v4', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('sheets', 'v4', credentials=creds)
 
     # Call the Sheets API
     sheet = service.spreadsheets()

--- a/slides/quickstart/README.md
+++ b/slides/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Slides API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/slides/quickstart/quickstart.py
+++ b/slides/quickstart/quickstart.py
@@ -14,11 +14,13 @@
 
 # [START slides_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/presentations.readonly'
 
 # The ID of a sample presentation.
@@ -28,15 +30,26 @@ def main():
     """Shows basic usage of the Slides API.
     Prints the number of slides and elments in a sample presentation.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('slides', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('slides', 'v1', credentials=creds)
 
     # Call the Slides API
     presentation = service.presentations().get(

--- a/tasks/quickstart/README.md
+++ b/tasks/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Tasks API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/tasks/quickstart/quickstart.py
+++ b/tasks/quickstart/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START tasks_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/tasks.readonly'
 
 def main():
     """Shows basic usage of the Tasks API.
     Prints the title and ID of the first 10 task lists.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('tasks', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('tasks', 'v1', credentials=creds)
 
     # Call the Tasks API
     results = service.tasklists().list(maxResults=10).execute()

--- a/vault/quickstart/README.md
+++ b/vault/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Vault API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client oauth2client
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
 ```
 
 ## Run

--- a/vault/quickstart/quickstart.py
+++ b/vault/quickstart/quickstart.py
@@ -14,26 +14,39 @@
 
 # [START vault_quickstart]
 from __future__ import print_function
+import pickle
+import os.path
 from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import file, client, tools
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
 
-# If modifying these scopes, delete the file token.json.
+# If modifying these scopes, delete the file token.pickle.
 SCOPES = 'https://www.googleapis.com/auth/ediscovery'
 
 def main():
     """Shows basic usage of the Vault API.
     Prints the names and IDs of the first 10 matters in Vault.
     """
-    # The file token.json stores the user's access and refresh tokens, and is
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    store = file.Storage('token.json')
-    creds = store.get()
-    if not creds or creds.invalid:
-        flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
-        creds = tools.run_flow(flow, store)
-    service = build('vault', 'v1', http=creds.authorize(Http()))
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server()
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    service = build('vault', 'v1', credentials=creds)
 
     # Call the Vault API
     results = service.matters().list(pageSize=10).execute()


### PR DESCRIPTION
This is a start at tackling #10. Please review so I can convert [all samples](https://github.com/gsuitedevs/python-samples/issues/10#issuecomment-447011414) in one go.

Unfortunately, we are losing `oauth2client.file.Storage`, so we have to manually (de)serialize and write/read the token file. The solution I have used here is to use pickle, but this adds another dependency, and a bunch of lines of boilerplate code. There might be a better solution.