### PR TITLE
Fixes to quickstarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ client_secret.json
 application_credentials.json
 storage.json
 credentials.json
-token.json
+token.pickle
 
 .DS_Store
 

--- a/admin_sdk/directory/README.md
+++ b/admin_sdk/directory/README.md
@@ -8,7 +8,7 @@ Directory API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/admin_sdk/directory/quickstart.py
+++ b/admin_sdk/directory/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/admin.directory.user'
+SCOPES = ['https://www.googleapis.com/auth/admin.directory.user']
 
 def main():
     """Shows basic usage of the Admin SDK Directory API.

--- a/admin_sdk/reports/README.md
+++ b/admin_sdk/reports/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reports API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/admin_sdk/reports/quickstart.py
+++ b/admin_sdk/reports/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/admin.reports.audit.readonly'
+SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly']
 
 def main():
     """Shows basic usage of the Admin SDK Reports API.

--- a/admin_sdk/reseller/README.md
+++ b/admin_sdk/reseller/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reseller API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/admin_sdk/reseller/quickstart.py
+++ b/admin_sdk/reseller/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/apps.order'
+SCOPES = ['https://www.googleapis.com/auth/apps.order']
 
 def main():
     """Calls the Admin SDK Reseller API. Prints the customer ID, SKU ID,

--- a/apps_script/quickstart/README.md
+++ b/apps_script/quickstart/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Apps Script API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/apps_script/quickstart/quickstart.py
+++ b/apps_script/quickstart/quickstart.py
@@ -27,7 +27,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/script.projects'
+SCOPES = ['https://www.googleapis.com/auth/script.projects']
 
 SAMPLE_CODE = '''
 function helloWorld() {

--- a/calendar/quickstart/README.md
+++ b/calendar/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Calendar API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/calendar/quickstart/quickstart.py
+++ b/calendar/quickstart/quickstart.py
@@ -22,7 +22,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/calendar.readonly'
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 
 def main():
     """Shows basic usage of the Google Calendar API.

--- a/classroom/quickstart/README.md
+++ b/classroom/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Classroom API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/classroom/quickstart/quickstart.py
+++ b/classroom/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/classroom.courses.readonly'
+SCOPES = ['https://www.googleapis.com/auth/classroom.courses.readonly']
 
 def main():
     """Shows basic usage of the Classroom API.

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/drive.activity.readonly'
+SCOPES = ['https://www.googleapis.com/auth/drive.activity.readonly']
 
 
 def main():

--- a/drive/activity/quickstart.py
+++ b/drive/activity/quickstart.py
@@ -22,7 +22,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/activity'
+SCOPES = ['https://www.googleapis.com/auth/activity']
 
 def main():
     """Shows basic usage of the Drive Activity API.

--- a/drive/quickstart/README.md
+++ b/drive/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Drive V3 API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/drive/quickstart/quickstart.py
+++ b/drive/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/drive.metadata.readonly'
+SCOPES = ['https://www.googleapis.com/auth/drive.metadata.readonly']
 
 def main():
     """Shows basic usage of the Drive v3 API.

--- a/gmail/quickstart/README.md
+++ b/gmail/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Gmail API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/gmail/quickstart/quickstart.py
+++ b/gmail/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/gmail.readonly'
+SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
 
 def main():
     """Shows basic usage of the Gmail API.

--- a/people/quickstart/README.md
+++ b/people/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google People API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/people/quickstart/quickstart.py
+++ b/people/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/contacts.readonly'
+SCOPES = ['https://www.googleapis.com/auth/contacts.readonly']
 
 def main():
     """Shows basic usage of the People API.

--- a/sheets/quickstart/README.md
+++ b/sheets/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Sheets API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 

--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/spreadsheets.readonly'
+SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly']
 
 # The ID and range of a sample spreadsheet.
 SAMPLE_SPREADSHEET_ID = '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms'

--- a/slides/quickstart/README.md
+++ b/slides/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Slides API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/slides/quickstart/quickstart.py
+++ b/slides/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/presentations.readonly'
+SCOPES = ['https://www.googleapis.com/auth/presentations.readonly']
 
 # The ID of a sample presentation.
 PRESENTATION_ID = '1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc'

--- a/tasks/quickstart/README.md
+++ b/tasks/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Tasks API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/tasks/quickstart/quickstart.py
+++ b/tasks/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/tasks.readonly'
+SCOPES = ['https://www.googleapis.com/auth/tasks.readonly']
 
 def main():
     """Shows basic usage of the Tasks API.

--- a/vault/quickstart/README.md
+++ b/vault/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Vault API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib pickle
+pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
 ## Run

--- a/vault/quickstart/quickstart.py
+++ b/vault/quickstart/quickstart.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
 # If modifying these scopes, delete the file token.pickle.
-SCOPES = 'https://www.googleapis.com/auth/ediscovery'
+SCOPES = ['https://www.googleapis.com/auth/ediscovery']
 
 def main():
     """Shows basic usage of the Vault API.


### PR DESCRIPTION
- Make `SCOPES` an array, to avoid error `ValueError: Invalid scope (https://www.googleapis.com/auth/calendar.readonly), must be string, tuple, set, or list.`
- Remove `pickle` from the `pip install` command, as it doesn't seem to be a valid pip package. 
- Add `token.pickle` to the .gitignore file.