### PR TITLE
Update main.py for Python2 and Python3 user input support

### DIFF
--- a/drive/driveapp/main.py
+++ b/drive/driveapp/main.py
@@ -6,17 +6,12 @@ This script uploads a single file to Google Drive.
 """
 
 from __future__ import print_function
+import six
 import pprint
 import httplib2
 from googleapiclient.discovery import build
 import googleapiclient.http
 import oauth2client.client
-
-#Add user input support for both Python2 and Python3
-try: 
-    input = raw_input # Python2
-except:
-    pass # Python3
 
 # OAuth 2.0 scope that will be authorized.
 # Check https://developers.google.com/drive/scopes for all available scopes.
@@ -38,8 +33,8 @@ flow = oauth2client.client.flow_from_clientsecrets(CLIENT_SECRETS, OAUTH2_SCOPE)
 flow.redirect_uri = oauth2client.client.OOB_CALLBACK_URN
 authorize_url = flow.step1_get_authorize_url()
 print('Go to the following link in your browser: ' + authorize_url)
-# If you can't use Python 3.x, please change "input" to "raw_input"
-code = input('Enter verification code: ').strip()
+# Add user input support for both Python2 and Python3
+code = six.moves.input('Enter verification code: ').strip()
 credentials = flow.step2_exchange(code)
 
 # Create an authorized Drive API client.

--- a/drive/driveapp/main.py
+++ b/drive/driveapp/main.py
@@ -6,12 +6,12 @@ This script uploads a single file to Google Drive.
 """
 
 from __future__ import print_function
-import six
 import pprint
 import httplib2
 from googleapiclient.discovery import build
 import googleapiclient.http
 import oauth2client.client
+from builtins import input
 
 # OAuth 2.0 scope that will be authorized.
 # Check https://developers.google.com/drive/scopes for all available scopes.
@@ -33,8 +33,8 @@ flow = oauth2client.client.flow_from_clientsecrets(CLIENT_SECRETS, OAUTH2_SCOPE)
 flow.redirect_uri = oauth2client.client.OOB_CALLBACK_URN
 authorize_url = flow.step1_get_authorize_url()
 print('Go to the following link in your browser: ' + authorize_url)
-# Add user input support for both Python2 and Python3
-code = six.moves.input('Enter verification code: ').strip()
+# Should support both Python2 and Python3 with 'from builtins import input'
+code = input('Enter verification code: ').strip()
 credentials = flow.step2_exchange(code)
 
 # Create an authorized Drive API client.

--- a/drive/driveapp/main.py
+++ b/drive/driveapp/main.py
@@ -12,6 +12,12 @@ from googleapiclient.discovery import build
 import googleapiclient.http
 import oauth2client.client
 
+#Add user input support for both Python2 and Python3
+try: 
+    input = raw_input # Python2
+except:
+    pass # Python3
+
 # OAuth 2.0 scope that will be authorized.
 # Check https://developers.google.com/drive/scopes for all available scopes.
 OAUTH2_SCOPE = 'https://www.googleapis.com/auth/drive'

--- a/drive/driveapp/main.py
+++ b/drive/driveapp/main.py
@@ -8,10 +8,10 @@ This script uploads a single file to Google Drive.
 from __future__ import print_function
 import pprint
 import httplib2
+import six
 from googleapiclient.discovery import build
 import googleapiclient.http
 import oauth2client.client
-from builtins import input
 
 # OAuth 2.0 scope that will be authorized.
 # Check https://developers.google.com/drive/scopes for all available scopes.
@@ -33,8 +33,8 @@ flow = oauth2client.client.flow_from_clientsecrets(CLIENT_SECRETS, OAUTH2_SCOPE)
 flow.redirect_uri = oauth2client.client.OOB_CALLBACK_URN
 authorize_url = flow.step1_get_authorize_url()
 print('Go to the following link in your browser: ' + authorize_url)
-# Should support both Python2 and Python3 with 'from builtins import input'
-code = input('Enter verification code: ').strip()
+# `six` library supports Python2 and Python3 without redefining builtin input()
+code = six.moves.input('Enter verification code: ').strip()
 credentials = flow.step2_exchange(code)
 
 # Create an authorized Drive API client.

--- a/drive/driveapp/main.py
+++ b/drive/driveapp/main.py
@@ -7,8 +7,8 @@ This script uploads a single file to Google Drive.
 
 from __future__ import print_function
 import pprint
-import httplib2
 import six
+import httplib2
 from googleapiclient.discovery import build
 import googleapiclient.http
 import oauth2client.client


### PR DESCRIPTION
Add support for both Python2/Python3 rather than asking user to manually change the code as suggested in this comment: # If you can't use Python 3.x, please change "input" to "raw_input"