### PR TITLE
Add requirements.txt to all quickstarts

### DIFF
--- a/admin_sdk/directory/README.md
+++ b/admin_sdk/directory/README.md
@@ -8,7 +8,7 @@ Directory API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/admin_sdk/directory/requirements.txt
+++ b/admin_sdk/directory/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/admin_sdk/reports/README.md
+++ b/admin_sdk/reports/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reports API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/admin_sdk/reports/requirements.txt
+++ b/admin_sdk/reports/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/admin_sdk/reseller/README.md
+++ b/admin_sdk/reseller/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Admin SDK Reseller API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/admin_sdk/reseller/requirements.txt
+++ b/admin_sdk/reseller/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/apps_script/quickstart/README.md
+++ b/apps_script/quickstart/README.md
@@ -8,7 +8,7 @@ that makes requests to the Google Apps Script API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/apps_script/quickstart/requirements.txt
+++ b/apps_script/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/calendar/quickstart/README.md
+++ b/calendar/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Calendar API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/calendar/quickstart/requirements.txt
+++ b/calendar/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/classroom/quickstart/README.md
+++ b/classroom/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Google Classroom API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/classroom/quickstart/requirements.txt
+++ b/classroom/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/drive/activity-v2/requirements.txt
+++ b/drive/activity-v2/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/drive/activity/requirements.txt
+++ b/drive/activity/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/drive/quickstart/README.md
+++ b/drive/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Drive V3 API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/drive/quickstart/requirements.txt
+++ b/drive/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/gmail/quickstart/README.md
+++ b/gmail/quickstart/README.md
@@ -8,7 +8,7 @@ makes requests to the Gmail API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/gmail/quickstart/requirements.txt
+++ b/gmail/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/people/quickstart/README.md
+++ b/people/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google People API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/people/quickstart/requirements.txt
+++ b/people/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/sheets/quickstart/README.md
+++ b/sheets/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Sheets API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 

--- a/sheets/quickstart/requirements.txt
+++ b/sheets/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/slides/quickstart/README.md
+++ b/slides/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Slides API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/slides/quickstart/requirements.txt
+++ b/slides/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/tasks/quickstart/README.md
+++ b/tasks/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Tasks API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/tasks/quickstart/requirements.txt
+++ b/tasks/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0

--- a/vault/quickstart/README.md
+++ b/vault/quickstart/README.md
@@ -8,7 +8,7 @@ requests to the Google Vault API.
 ## Install
 
 ```
-pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+pip install -r requirements.txt
 ```
 
 ## Run

--- a/vault/quickstart/requirements.txt
+++ b/vault/quickstart/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0


### PR DESCRIPTION
Fixes #2.
- Adds the standard `requirements.txt` file to each quickstart directory.
  - Rather than "pip install <libs>", we are using the standard "pip install -r".
  - This change is independent of DevSite instructions.

---

This ensures the compatibility of the dependencies so that we don't see a quickstart randomly break.

Tested locally.

Ideally the user has venv set up, but we've never enforced that or added that to the quickstart docs.

This `requirements.txt` setup is similar to what we can see in the [GCP python repo](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/dlp/requirements.txt).