### PR TITLE
Change the default port to 8090

### DIFF
--- a/admin_sdk/directory/quickstart.py
+++ b/admin_sdk/directory/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/admin_sdk/reports/quickstart.py
+++ b/admin_sdk/reports/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/admin_sdk/reseller/quickstart.py
+++ b/admin_sdk/reseller/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/apps_script/quickstart/quickstart.py
+++ b/apps_script/quickstart/quickstart.py
@@ -59,7 +59,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/calendar/quickstart/quickstart.py
+++ b/calendar/quickstart/quickstart.py
@@ -42,7 +42,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/classroom/quickstart/quickstart.py
+++ b/classroom/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/docs/quickstart/quickstart.py
+++ b/docs/quickstart/quickstart.py
@@ -44,7 +44,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -43,7 +43,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/drive/activity/quickstart.py
+++ b/drive/activity/quickstart.py
@@ -42,7 +42,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/drive/quickstart/quickstart.py
+++ b/drive/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/gmail/quickstart/quickstart.py
+++ b/gmail/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/people/quickstart/quickstart.py
+++ b/people/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -45,7 +45,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/slides/quickstart/quickstart.py
+++ b/slides/quickstart/quickstart.py
@@ -44,7 +44,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/tasks/quickstart/quickstart.py
+++ b/tasks/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/vault/quickstart/quickstart.py
+++ b/vault/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=8090)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)


### PR DESCRIPTION
The default port 8080 is more likely to be in use, and the library doesn't handle that case gracefully. Fixes #86.