### PR TITLE
Credentials check before read

### DIFF
--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -15,6 +15,7 @@
 # [START sheets_quickstart]
 from __future__ import print_function
 import pickle
+import sys
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -43,9 +44,17 @@ def main():
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(
+            if os.path.exists('credentials.json'):
+                flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+                creds = flow.run_local_server()
+            else:
+                print('\n\'credentials.json\' file not found. Before running again, '
+                'please follow Step 1 of Quickstart to'
+                ' download the \'credentials.json\' file here: \n\n'
+                'https://developers.google.com/sheets/api/quickstart/'
+                'python#step_1_turn_on_the\n')
+                sys.exit()
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -15,7 +15,7 @@
 # [START sheets_quickstart]
 from __future__ import print_function
 import pickle
-import sys
+from sys import exit
 import os.path
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -54,7 +54,7 @@ def main():
                 ' download the \'credentials.json\' file here: \n\n'
                 'https://developers.google.com/sheets/api/quickstart/'
                 'python#step_1_turn_on_the\n')
-                sys.exit()
+                exit()
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)


### PR DESCRIPTION
This pull request addresses the enhancement in #111 . Basically, if a user follows the quickstart instructions out of order by running `python quickstart.py` before downloading `credentials.json` in step 1 of the API quickstart, the program throws an uncaught error -  "cannot find 'credentials.json'". I added an error catch for this in sheets/quickstart that directs the user to follow Step 1. If this solution looks okay I can make the changes to each of the other quickstarts. 