### PR TITLE
Fallback Creds

### DIFF
--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -45,7 +45,10 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            try:
+                creds = flow.run_local_server()
+            except:
+                creds = flow.run_console()
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -47,7 +47,8 @@ def main():
                 'credentials.json', SCOPES)
             try:
                 creds = flow.run_local_server()
-            except:
+            except OSError as e:
+                print(e)
                 creds = flow.run_console()
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:


### PR DESCRIPTION
When doing the [Python Quickstart](https://developers.google.com/sheets/api/quickstart/python) for Google Sheets, on Windows 10, it gives an error:

`[WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions`

It's caused by `creds = flow.run_local_server()`

This PR adds a fallback to it shows a different auth method, as per the docs: "_ If this fails, copy the URL from the console and manually open it in your browser._"

