### PR TITLE
Update oauthlib, set port to 0 in oauth flow to use ephemeral ports.

### DIFF
--- a/admin_sdk/directory/quickstart.py
+++ b/admin_sdk/directory/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/admin_sdk/directory/requirements.txt
+++ b/admin_sdk/directory/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/admin_sdk/reports/quickstart.py
+++ b/admin_sdk/reports/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/admin_sdk/reports/requirements.txt
+++ b/admin_sdk/reports/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/admin_sdk/reseller/quickstart.py
+++ b/admin_sdk/reseller/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/admin_sdk/reseller/requirements.txt
+++ b/admin_sdk/reseller/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/apps_script/quickstart/quickstart.py
+++ b/apps_script/quickstart/quickstart.py
@@ -59,7 +59,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/apps_script/quickstart/requirements.txt
+++ b/apps_script/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/calendar/quickstart/quickstart.py
+++ b/calendar/quickstart/quickstart.py
@@ -42,7 +42,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/calendar/quickstart/requirements.txt
+++ b/calendar/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/classroom/quickstart/quickstart.py
+++ b/classroom/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/classroom/quickstart/requirements.txt
+++ b/classroom/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/docs/quickstart/quickstart.py
+++ b/docs/quickstart/quickstart.py
@@ -44,7 +44,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/docs/quickstart/requirements.txt
+++ b/docs/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/drive/activity-v2/quickstart.py
+++ b/drive/activity-v2/quickstart.py
@@ -43,7 +43,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/drive/activity-v2/requirements.txt
+++ b/drive/activity-v2/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/drive/activity/quickstart.py
+++ b/drive/activity/quickstart.py
@@ -42,7 +42,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/drive/activity/requirements.txt
+++ b/drive/activity/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/drive/quickstart/quickstart.py
+++ b/drive/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/drive/quickstart/requirements.txt
+++ b/drive/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/gmail/quickstart/quickstart.py
+++ b/gmail/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/people/quickstart/quickstart.py
+++ b/people/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/people/quickstart/requirements.txt
+++ b/people/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/sheets/quickstart/quickstart.py
+++ b/sheets/quickstart/quickstart.py
@@ -45,7 +45,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/sheets/quickstart/requirements.txt
+++ b/sheets/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/slides/quickstart/quickstart.py
+++ b/slides/quickstart/quickstart.py
@@ -44,7 +44,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/slides/quickstart/requirements.txt
+++ b/slides/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/tasks/quickstart/quickstart.py
+++ b/tasks/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/tasks/quickstart/requirements.txt
+++ b/tasks/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0

--- a/vault/quickstart/quickstart.py
+++ b/vault/quickstart/quickstart.py
@@ -41,7 +41,7 @@ def main():
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)
-            creds = flow.run_local_server()
+            creds = flow.run_local_server(port=0)
         # Save the credentials for the next run
         with open('token.pickle', 'wb') as token:
             pickle.dump(creds, token)

--- a/vault/quickstart/requirements.txt
+++ b/vault/quickstart/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.7.8
+google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
+google-auth-oauthlib==0.4.0


### PR DESCRIPTION
Fixes #86. Use port 0 to pick an ephemeral port that won't cause a conflict with other processes. Requires latest version of oauthlib.
